### PR TITLE
Add replayer for capture files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,6 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 /ZwiftActivityMonitor/nsis-setup/Setup-ZAM.exe
+
+# Launch settings are user specific
+launchSettings.json

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ See the included ZwiftPacketMonitor.Demo project for a complete working example.
     monitor.StopCaptureAsync().Wait();
 ```
 
+## Replay Zwift messages
+
+Debugging is hard but it's even harder when having to do a Zwift work out at the same time!
+
+To make life easier you can replay Zwift messages from a PCAP capture file instead of a network device so that you can debug and analyse without having to run Zwift at the same time.
+Capture packets using SharpCap or Wireshark and save the results to a file, then run `ZwiftPacketMonitor.Replay.exe <path to capture file>` and see the messages flow by.
+
 ## Credit
 This project is a .NET port of the [zwift-packet-monitor](https://github.com/jeroni7100/zwift-packet-monitor) project and borrows heavily from its packet handling and protobuf implementation.
 

--- a/ZwiftPacketMonitor.Replay/DependencyRegistration.cs
+++ b/ZwiftPacketMonitor.Replay/DependencyRegistration.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ZwiftPacketMonitor.Replay
+{
+    class DependencyRegistration
+    {
+        public static ServiceProvider Register()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            // added to allow logging level configuration, change MinLevel to LogLevel.Debug to see internal traces.
+            serviceCollection.AddLogging(configure => configure.AddConsole())
+                .Configure<LoggerFilterOptions>(configure => configure.MinLevel = LogLevel.Information);
+
+            serviceCollection.AddZwiftPacketMonitoring();
+            serviceCollection.AddSingleton<Replay>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            return serviceProvider;
+        }
+    }
+}

--- a/ZwiftPacketMonitor.Replay/Program.cs
+++ b/ZwiftPacketMonitor.Replay/Program.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ZwiftPacketMonitor.Replay
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("ZwiftPacketMonitor capture replay");
+
+            if (args.Length != 1)
+            {
+                Console.Error.WriteLine("Usage: ZwiftPacketMonitor.Replay.exe <path to capture file>");
+                Environment.Exit(1);
+            }
+
+            var path = args[0];
+
+            if (!File.Exists(path))
+            {
+                Console.Error.WriteLine("Capture file not found");
+                Environment.Exit(1);
+            }
+            
+            var serviceProvider = DependencyRegistration.Register();
+
+            var logger = serviceProvider.GetService<ILogger<Program>>();
+            var replay = serviceProvider.GetService<Replayer>();
+            
+            replay.IncomingPlayerEvent += (s, e) =>
+            {
+                logger.LogInformation($"INCOMING: {e.PlayerState}");
+            };
+            replay.OutgoingPlayerEvent += (s, e) =>
+            {
+                logger.LogInformation($"OUTGOING: {e.PlayerState}");
+            };
+            replay.IncomingChatMessageEvent += (s, e) =>
+            {
+                logger.LogInformation($"CHAT: {e.Message}");
+            };
+            replay.IncomingPlayerEnteredWorldEvent += (s, e) =>
+            {
+                logger.LogInformation($"WORLD: {e.PlayerUpdate}");
+            };
+            replay.IncomingRideOnGivenEvent += (s, e) =>
+            {
+                logger.LogInformation($"RIDEON: {e.RideOn}");
+            };
+
+            replay.FromCapture(path);
+        }
+    }
+}

--- a/ZwiftPacketMonitor.Replay/ZwiftPacketMonitor.Replay.csproj
+++ b/ZwiftPacketMonitor.Replay/ZwiftPacketMonitor.Replay.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="SharpPcap" Version="6.0.0" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ZwiftPacketMonitor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ZwiftPacketMonitor.sln
+++ b/ZwiftPacketMonitor.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZwiftPacketMonitor.Demo", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZwiftPacketMonitor.Tests", "test\ZwiftPacketMonitor.Tests.csproj", "{0D8E87EF-D132-4D89-A1BB-E69890B39831}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZwiftPacketMonitor.Replay", "ZwiftPacketMonitor.Replay\ZwiftPacketMonitor.Replay.csproj", "{EB87F3B2-FF56-4C89-A712-37EC943D11C1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{0D8E87EF-D132-4D89-A1BB-E69890B39831}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D8E87EF-D132-4D89-A1BB-E69890B39831}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D8E87EF-D132-4D89-A1BB-E69890B39831}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB87F3B2-FF56-4C89-A712-37EC943D11C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB87F3B2-FF56-4C89-A712-37EC943D11C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB87F3B2-FF56-4C89-A712-37EC943D11C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB87F3B2-FF56-4C89-A712-37EC943D11C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Monitor.cs
+++ b/src/Monitor.cs
@@ -303,7 +303,7 @@ namespace ZwiftPacketMonitor
             return (device.Addresses[0]?.Addr?.ipAddress == null ? device.Name : device.Addresses[0].Addr.ipAddress.ToString());
         }
 
-        private void device_OnPacketArrival(object sender, PacketCapture e)
+        protected void device_OnPacketArrival(object sender, PacketCapture e)
         {
             try 
             {

--- a/src/Replayer.cs
+++ b/src/Replayer.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using Microsoft.Extensions.Logging;
+using SharpPcap;
+using SharpPcap.LibPcap;
+
+namespace ZwiftPacketMonitor
+{
+    /// <summary>
+    /// Reads Zwift messages from a PCAP file instead of a network device
+    /// </summary>
+    public class Replayer : Monitor
+    {
+        public Replayer(ILogger<Monitor> logger, PacketAssembler packetAssembler) 
+            : base(logger, packetAssembler)
+        {
+        }
+
+        public void FromCapture(string path)
+        {
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException("Capture file not found", path);
+            }
+
+            using var device = new CaptureFileReaderDevice(path);
+
+            device.Open();
+            device.OnPacketArrival += device_OnPacketArrival;
+            device.Capture();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a command line utility that you can point at a PCAP file in order to easily debug messages that were captured during a Zwift session.

Should save a lot of sweat trying to analyse or reproduce issues ;-)